### PR TITLE
bugfix/accurics_remediation_5791637689867603 - Auto Generated Pull Request From Accurics

### DIFF
--- a/aws/vpc.tf
+++ b/aws/vpc.tf
@@ -7,3 +7,56 @@ resource "aws_vpc" "tenable_cs_demo_vpc" {
     }
   )
 }
+resource "aws_flow_log" "tenable_cs_demo_vpc" {
+  vpc_id          = "${aws_vpc.tenable_cs_demo_vpc.id}"
+  iam_role_arn    = "<iam_role_arn>"
+  log_destination = "${aws_s3_bucket.tenable_cs_demo_vpc.arn}"
+  traffic_type    = "ALL"
+
+  tags = {
+    GeneratedBy      = "Accurics"
+    ParentResourceId = "aws_vpc.tenable_cs_demo_vpc"
+  }
+}
+resource "aws_s3_bucket" "tenable_cs_demo_vpc" {
+  bucket        = "tenable_cs_demo_vpc_flow_log_s3_bucket"
+  acl           = "private"
+  force_destroy = true
+
+  versioning {
+    enabled    = true
+    mfa_delete = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+resource "aws_s3_bucket_policy" "tenable_cs_demo_vpc" {
+  bucket = "${aws_s3_bucket.tenable_cs_demo_vpc.id}"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "tenable_cs_demo_vpc-restrict-access-to-users-or-roles",
+      "Effect": "Allow",
+      "Principal": [
+        {
+          "AWS": [
+            <principal_arn>
+          ]
+        }
+      ],
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::${aws_s3_bucket.tenable_cs_demo_vpc.id}/*"
+    }
+  ]
+}
+POLICY
+}


### PR DESCRIPTION
Perform the following to determine if VPC Flow logs is enabled:

**From Console:**

1. Sign into the management console
2. Select 'Services' then 'VPC' 
3. In the left navigation pane, select 'Your VPCs' 
4. Select a VPC
5. In the right pane, select the 'Flow Logs' tab.
6. If no Flow Log exists, click 'Create Flow Log' 
7. For Filter, select 'Reject'
8. Enter in a 'Role' and 'Destination Log Group' 
9. Click 'Create Log Flow' 
10. Click on 'CloudWatch Logs Group' 

**Note:** Setting the filter to "Reject" will dramatically reduce the logging data accumulation for this recommendation and provide sufficient information for the purposes of breach detection, research and remediation. However, during periods of least privilege security group engineering, setting this the filter to "All" can be very helpful in discovering existing traffic flows required for proper operation of an already running environment.

**From Command Line:**

1. Create a policy document and name it as 'role_policy_document.json' and paste the following content:

{
 "Version": "2012-10-17",
 "Statement": [
 {
 "Sid": "test",
 "Effect": "Allow",
 "Principal": {
 "Service": "ec2.amazonaws.com"
 },
 "Action": "sts:AssumeRole"
 }
 ]
}

2. Create another policy document and name it as 'iam_policy.json' and paste the following content:

{
 "Version": "2012-10-17",
 "Statement": [
 {
 "Effect": "Allow",
 "Action":[
 "logs:CreateLogGroup",
 "logs:CreateLogStream",
 "logs:DescribeLogGroups",
 "logs:DescribeLogStreams",
 "logs:PutLogEvents",
 "logs:GetLogEvents",
 "logs:FilterLogEvents"
 ],
 "Resource": "*"
 }
 ]
}

3. Run the below command to create an IAM role:

aws iam create-role --role-name <aws_support_iam_role> --assume-role-policy-document file://<file-path>role_policy_document.json 

4. Run the below command to create an IAM policy:

aws iam create-policy --policy-name <ami-policy-name> --policy-document file://<file-path>iam-policy.json

5. Run 'attach-group-policy' command using the IAM policy ARN returned at the previous step to attach the policy to the IAM role (if the command succeeds, no output is returned):

aws iam attach-group-policy --policy-arn arn:aws:iam::<aws-account-id>:policy/<iam-policy-name> --group-name <group-name>

6. Run 'describe-vpcs' to get the VpcId available in the selected region:

aws ec2 describe-vpcs --region <region>

7. The command output should return the VPC Id available in the selected region.
8. Run 'create-flow-logs' to create a flow log for the vpc:

aws ec2 create-flow-logs --resource-type VPC --resource-ids <vpc-id> --traffic-type REJECT --log-group-name <log-group-name> --deliver-logs-permission-arn <iam-role-arn>

9. Repeat step 8 for other vpcs available in the selected region.
10. Change the region by updating --region and repeat remediation procedure for other vpcs.